### PR TITLE
no_bitmanip

### DIFF
--- a/regress/cv32e40x_full.yaml
+++ b/regress/cv32e40x_full.yaml
@@ -169,7 +169,7 @@ tests:
 
   perf_counters_instructions:
     description: Performance counter test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
+    builds: [ uvmt_cv32e40x ]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=perf_counters_instructions
 
@@ -225,7 +225,7 @@ tests:
 
   corev_rand_arithmetic_base_test:
     description: Generated corev-dv arithmetic test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5 ]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_arithmetic_base_test
     num: 4


### PR DESCRIPTION
This PR removes references to the "no_bitmanip" build in the "full" regression.

_(This should already have been done during the previous S->X merge, but I somehow resolved that particular conflict wrong.)_