### PR TITLE
remove CLIC_INTTHRESHBITS

### DIFF
--- a/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -52,7 +52,6 @@ module uvmt_cv32e40x_dut_wrap
     parameter pma_cfg_t              PMA_CFG[PMA_NUM_REGIONS-1 : 0]      = '{default:PMA_R_DEFAULT},
     parameter logic                  CLIC                                = 0,
     parameter int                    CLIC_ID_WIDTH                       = 5,
-    parameter int                    CLIC_INTTHRESHBITS                  = 8,
     parameter int                    DBG_NUM_TRIGGERS                    = 1,
     parameter rv32_e                 RV32                                = RV32I,
 
@@ -172,8 +171,7 @@ module uvmt_cv32e40x_dut_wrap
                       .PMA_NUM_REGIONS      (PMA_NUM_REGIONS),
                       .RV32                 (RV32),
                       .CLIC                 (CLIC),
-                      .CLIC_ID_WIDTH        (CLIC_ID_WIDTH),
-                      .CLIC_INTTHRESHBITS   (CLIC_INTTHRESHBITS)
+                      .CLIC_ID_WIDTH        (CLIC_ID_WIDTH)
                       )
     cv32e40x_wrapper_i
         (

--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -112,7 +112,6 @@ module uvmt_cv32e40x_tb;
                              .B_EXT                (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_B_EXT),
                              .CLIC                 (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_CLIC),
                              .CLIC_ID_WIDTH        (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_CLIC_ID_WIDTH),
-                             .CLIC_INTTHRESHBITS   (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_CLIC_INTTHRESHBITS),
                              .DBG_NUM_TRIGGERS     (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DBG_NUM_TRIGGERS),
                              .DM_REGION_END        (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DM_REGION_END),
                              .DM_REGION_START      (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DM_REGION_START),

--- a/tests/uvmt/base-tests/uvmt_cv32e40x_base_test_constants.sv
+++ b/tests/uvmt/base-tests/uvmt_cv32e40x_base_test_constants.sv
@@ -130,7 +130,6 @@ parameter logic CLIC = CORE_PARAM_CLIC;
 `elsif PARAM_SET_1
    // Sat from the include file
 `else
-   parameter int  CORE_PARAM_CLIC_INTTHRESHBITS = 8;
    parameter int  CORE_PARAM_CLIC_ID_WIDTH = 5;
 `endif
 


### PR DESCRIPTION
The cv32e40x core has removed CLIC_INTTHRESHBITS, so to get formal to run we need to do it in the verification environment aswell.

I coudnt see any missing dependencies, do you know something about this @silabs-hfegran ?

ci_check passes, and formal compiles.