### PR TITLE
pma atomic, TODO: for pma assert

### DIFF
--- a/tb/assertions/uvmt_cv32e40x_pma_model.sv
+++ b/tb/assertions/uvmt_cv32e40x_pma_model.sv
@@ -18,7 +18,7 @@
 
 
 `default_nettype none
-
+//TODO: krdosvik, when disassembler PR is in.
 
 module  uvmt_cv32e40x_pma_model
   import cv32e40x_pkg::*;
@@ -108,7 +108,7 @@ module  uvmt_cv32e40x_pma_model
   wire logic  allow_data;
   assign  allow_data =
     cfg_effective.main  ||
-    (!misaligned_access_i && !core_trans_pushpop_i);
+    (!misaligned_access_i && !core_trans_pushpop_i);// && !core_trans_amo_i); //AMO instructions are modifiable (one operation includes both read and write of memory)
 
   wire logic  accesses_jvt;
   assign  accesses_jvt =
@@ -116,7 +116,7 @@ module  uvmt_cv32e40x_pma_model
     (addr_i <= (jvt_q + (4 * 8'b 1111_1111)));
 
   assign  pma_status_o.allow =
-    override_dm  ||
+    (override_dm) || // && !cfg_effective.atomic) ||
     (IS_INSTR_SIDE ? allow_instr : allow_data);
   assign  pma_status_o.main              = cfg_effective.main;
   assign  pma_status_o.bufferable        = cfg_effective.bufferable;

--- a/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -224,7 +224,7 @@ module uvmt_cv32e40x_dut_wrap
          .mcycle_o               ( /*todo: connect */             ),
 
          .irq_i                  ( interrupt_if.irq               ),
-         .wu_wfe_i               ( 1'b0                           ), // todo: hook up
+         .wu_wfe_i               (                                ), // todo: hook up (krdosvik, henrik have a fix)
          .clic_irq_i             ( clic_if.clic_irq               ),
          .clic_irq_id_i          ( clic_if.clic_irq_id            ),
          .clic_irq_level_i       ( clic_if.clic_irq_level         ),

--- a/tb/uvmt/uvmt_cv32e40x_pma_assert.sv
+++ b/tb/uvmt/uvmt_cv32e40x_pma_assert.sv
@@ -115,6 +115,7 @@ module  uvmt_cv32e40x_pma_assert
     (core_trans_i.addr inside {[DM_REGION_START:DM_REGION_END]})
     |->
     !pma_err
+    || (pma_err && core_trans_i.atop[5]) //TODO: krdosvik, not sure what core_trans_i is, but should fit the format.
   ) else `uvm_error(info_tag, "dmode in dregion is never blocked");
 
 

--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -814,7 +814,8 @@ module uvmt_cv32e40x_tb;
         .DM_REGION_START (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DM_REGION_START),
         .IS_INSTR_SIDE   (1),
         .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG)
+        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG),
+        .A_EXT           (cv32e40x_pkg::A_NONE)
       ) pma_assert_instr_i (
         .obi_memory_if    (dut_wrap.obi_instr_if),
         .rvfi_instr_if    (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),
@@ -822,6 +823,7 @@ module uvmt_cv32e40x_tb;
         .writebuf_trans_i ('0),
         .writebuf_trans_o ('0),
         .pma_status_i     (uvmt_cv32e40x_tb.pma_status_instr),
+        .core_trans_atop  ('0),
         .*
       );
 
@@ -832,7 +834,8 @@ module uvmt_cv32e40x_tb;
         .DM_REGION_START (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DM_REGION_START),
         .IS_INSTR_SIDE   (0),
         .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG)
+        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG),
+        .A_EXT           (cv32e40x_pkg::A)
       ) pma_assert_data_i (
         .obi_memory_if    (dut_wrap.obi_data_if),
         .rvfi_instr_if    (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),
@@ -840,6 +843,7 @@ module uvmt_cv32e40x_tb;
         .writebuf_trans_i (dut_wrap.cv32e40x_wrapper_i.core_i.load_store_unit_i.write_buffer_i.trans_i),
         .writebuf_trans_o (dut_wrap.cv32e40x_wrapper_i.core_i.load_store_unit_i.write_buffer_i.trans_o),
         .pma_status_i     (uvmt_cv32e40x_tb.pma_status_data),
+        .core_trans_atop  (dut_wrap.cv32e40x_wrapper_i.core_i.load_store_unit_i.mpu_i.pma_assert_data_i.core_trans_i.atop),
         .*
       );
 

--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -814,8 +814,7 @@ module uvmt_cv32e40x_tb;
         .DM_REGION_START (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DM_REGION_START),
         .IS_INSTR_SIDE   (1),
         .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG),
-        .A_EXT           (cv32e40x_pkg::A_NONE)
+        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG)
       ) pma_assert_instr_i (
         .obi_memory_if    (dut_wrap.obi_instr_if),
         .rvfi_instr_if    (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),
@@ -834,8 +833,7 @@ module uvmt_cv32e40x_tb;
         .DM_REGION_START (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_DM_REGION_START),
         .IS_INSTR_SIDE   (0),
         .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG),
-        .A_EXT           (cv32e40x_pkg::A)
+        .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG)
       ) pma_assert_data_i (
         .obi_memory_if    (dut_wrap.obi_data_if),
         .rvfi_instr_if    (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),


### PR DESCRIPTION
Add todo for fixing pma assert when disassembler is in
Take into account atomic in pma assert

When running for a while::
![image](https://github.com/openhwgroup/cv32e40x-dv/assets/110398284/e1a854ab-00e6-423f-ae6c-0fe8d1a01764)

Formal compiles