### PR TITLE
Fixed hpmcounter_basic tests + mhpmcounter29_csr_access_test_2

### DIFF
--- a/tests/cfg/num_mhpmcounter_29.yaml
+++ b/tests/cfg/num_mhpmcounter_29.yaml
@@ -8,7 +8,8 @@ plusargs: >
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-    +DISABLE_CSR_CHECK=mcountinhibit
-    # FIXME: Remove the DISABLE_CSR_CHECK when correct reset value is implemented in the ISS
+ovpsim: >
+  --override refRoot/cpu/noinhibit_mask=0x00000002
+  --override refRoot/cpu/extension_CVE4X/mcountinhibit_reset=0xfffffffd
 cv_sw_march: >
     rv32im_zca_zicsr_zifencei_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/tests/programs/custom/hpmcounter_basic_test/hpmcounter_basic_test.c
+++ b/tests/programs/custom/hpmcounter_basic_test/hpmcounter_basic_test.c
@@ -299,29 +299,26 @@ int main(int argc, char *argv[])
   __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
 
-  __asm__ volatile("li x31, 7\n\t\
-                    li x30, 3\n\t\
-                    addi x0, x31, 1\n\t\
-                    lw x29, 0(sp)\n\t\
-                    lw x28, -1(sp)\n\t\
-                    srli x30, x29, 2\n\t\
-                    slli x30, x30, 2\n\t\
-                    xori x30, x30, 1\n\t\
-                    sw x29, 0(x30)\n\t\
-                    sw x29, 0(sp)\n\t\
-                    lw x28, -1(sp)\n\t\
-                    csrr x29, 0xB00\n\t\
-                    div x0, x31, x30" \
-                    : : : "x28", "x29", "x30", "x31");
+  __asm__ volatile(R"(
+                    addi sp, sp, -8
+                    sw sp, 1(sp)
+                    sw x0, 1(sp)
+                    sw x31, 1(sp)
+                    addi sp, sp, 8
+                    li x31, 7
+                    li x30, 3
+                    csrr x29, 0xB00
+                    div x0, x31, x30)"
+                    : : : "x29", "x30", "x31");
 
   __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
   __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
-  err_cnt += chck(minstret, 14);
+  err_cnt += chck(minstret, 10);
   printf("\nWrite port underutilization cycles: %d\n", count);
-  err_cnt += chck_with_pos_margin(count, 3, 14*MAX_STALL_CYCLES);
+  err_cnt += chck_with_pos_margin(count, 0, 3 + 3*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // Retired instruction count (0) - Immediate minstret read

--- a/tests/programs/custom/mhpmcounter29_csr_access_test_2/mhpmcounter29_csr_access_test_2.S
+++ b/tests/programs/custom/mhpmcounter29_csr_access_test_2/mhpmcounter29_csr_access_test_2.S
@@ -32,7 +32,6 @@
 .include "user_define.h"
 .section .text.start
 .globl _start
-.section .text
 #.include "user_init.s"
 .type _start, @function
 


### PR DESCRIPTION
- Original test code incorrect, updated to match intention
- Fixed error in mhpcounter29_csr_access_test_2 (code placed in wrong location)