### PR TITLE
Review Strategy Doc - Update Guidelines

### DIFF
--- a/docs/SX_Merge_PR_Review_Strat.md
+++ b/docs/SX_Merge_PR_Review_Strat.md
@@ -9,8 +9,7 @@ S->X PR review key points:
     * mhpmcounters, xif, etc.
     * (Auto-merging sometimes tries to delete X-features.)
 * Rejection Diff
-    * If the PRer adds a "rejection diff" it is useful to review.
-    * Check that updates weren't accidentally omitted.
+    * Read the "rejection diff", to heck that updates weren't accidentally omitted.
 * Familiar/Relevant Changes
     * Skim through the diff and see if it generally makes sense.
 * Test Results


### PR DESCRIPTION
This PR makes `docs/SX_Merge_PR_Review_Strat.md` stricter.

The "rejection diff" should be mandatory.
Therefore, now the review strat explicitly calls for a reviewer to read it.