### PR TITLE
Fixed a typo in that other PR

### DIFF
--- a/docs/SX_Merge_PR_Review_Strat.md
+++ b/docs/SX_Merge_PR_Review_Strat.md
@@ -9,7 +9,7 @@ S->X PR review key points:
     * mhpmcounters, xif, etc.
     * (Auto-merging sometimes tries to delete X-features.)
 * Rejection Diff
-    * Read the "rejection diff", to heck that updates weren't accidentally omitted.
+    * Read the "rejection diff", to check that updates weren't accidentally omitted.
 * Familiar/Relevant Changes
     * Skim through the diff and see if it generally makes sense.
 * Test Results


### PR DESCRIPTION
Why doesn't Github do simply let me fix my typo in that other PR?

I was hoping that making an edit directly in Githubs web UI would be easier than cloning the repo in my terminal etc etc.