### PR TITLE
Atomic sanity test

### DIFF
--- a/env/uvme/uvme_cv32e40x_cfg.sv
+++ b/env/uvme/uvme_cv32e40x_cfg.sv
@@ -28,6 +28,7 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
    // Integrals
    rand int unsigned                sys_clk_period;
    cv32e40x_pkg::b_ext_e            b_ext;
+   cv32e40x_pkg::a_ext_e            a_ext;
    bit                              obi_memory_instr_random_err_enabled     = 0;
    bit                              obi_memory_instr_one_shot_err_enabled   = 0;
    bit                              obi_memory_data_random_err_enabled      = 0;
@@ -67,6 +68,7 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
       `uvm_field_int (                         buserr_scoreboarding_enabled,          UVM_DEFAULT           )
       `uvm_field_int (                         sys_clk_period,                        UVM_DEFAULT | UVM_DEC )
       `uvm_field_enum (b_ext_e,                b_ext,                                 UVM_DEFAULT           )
+      `uvm_field_enum (a_ext_e,                a_ext,                                 UVM_DEFAULT           )
       `uvm_field_int (                         obi_memory_instr_random_err_enabled,   UVM_DEFAULT           )
       `uvm_field_int (                         obi_memory_instr_one_shot_err_enabled, UVM_DEFAULT           )
       `uvm_field_int (                         obi_memory_data_random_err_enabled,    UVM_DEFAULT           )
@@ -117,7 +119,6 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
       ext_m_supported         == 1;
       ext_zifencei_supported  == 1;
       ext_zicsr_supported     == 1;
-      ext_a_supported         == 0;
       ext_p_supported         == 0;
       ext_v_supported         == 0;
       ext_f_supported         == 0;
@@ -127,6 +128,12 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
       ext_zcmb_supported      == 0;
       ext_zcmp_supported      == 1;
       ext_zcmt_supported      == 1;
+
+      if (a_ext == cv32e40x_pkg::A_NONE) {
+         ext_a_supported == 0;
+      } else if (a_ext == cv32e40x_pkg::ZALRSC || a_ext == cv32e40x_pkg::A) {
+         ext_a_supported == 1;
+      }
 
       if (b_ext == cv32e40x_pkg::B_NONE) {
          ext_zba_supported == 0;
@@ -469,6 +476,7 @@ function void uvme_cv32e40x_cfg_c::sample_parameters(uvma_core_cntrl_cntxt_c cnt
    num_mhpmcounters = e40x_cntxt.core_cntrl_vif.num_mhpmcounters;
    pma_regions      = new[e40x_cntxt.core_cntrl_vif.pma_cfg.size()];
    b_ext            = e40x_cntxt.core_cntrl_vif.b_ext;
+   a_ext            = e40x_cntxt.core_cntrl_vif.a_ext;
 
    foreach (pma_regions[i]) begin
       pma_regions[i] = uvma_core_cntrl_pma_region_c::type_id::create($sformatf("pma_region%0d", i));

--- a/env/uvme/uvme_cv32e40x_core_cntrl_if.sv
+++ b/env/uvme/uvme_cv32e40x_core_cntrl_if.sv
@@ -26,6 +26,7 @@ interface uvme_cv32e40x_core_cntrl_if_t
     pma_cfg_t pma_cfg[16];
     `endif
     cv32e40x_pkg::b_ext_e b_ext;
+    cv32e40x_pkg::a_ext_e a_ext;
 
     // Testcase asserts this to load memory (not really a core control signal)
     logic        load_instr_mem;

--- a/regress/cv32e40x_full.yaml
+++ b/regress/cv32e40x_full.yaml
@@ -510,3 +510,8 @@ tests:
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_0_triggers
 
+  zalrsc:
+    description: Sanity test of ZALRSC extention
+    builds: [ uvmt_cv32e40x ]
+    dir: cv32e40x/sim/uvmt
+    cmd: make test TEST=zalrsc CFG=zalrsc_ext USE_ISS=0

--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -150,7 +150,9 @@ module uvmt_cv32e40x_tb;
 
   // Connect to core_cntrl_if
   assign core_cntrl_if.b_ext            = uvmt_cv32e40x_base_test_pkg::CORE_PARAM_B_EXT;
+  assign core_cntrl_if.a_ext            = uvmt_cv32e40x_base_test_pkg::CORE_PARAM_A_EXT;
   assign core_cntrl_if.num_mhpmcounters = uvmt_cv32e40x_base_test_pkg::CORE_PARAM_NUM_MHPMCOUNTERS;
+
   `ifndef FORMAL
     initial begin
       core_cntrl_if.pma_cfg = new[CORE_PARAM_PMA_NUM_REGIONS];

--- a/tests/cfg/zalrsc_ext.yaml
+++ b/tests/cfg/zalrsc_ext.yaml
@@ -1,0 +1,13 @@
+name: zalrsc_ext
+description: Enables the A extension ZALRSC in the cv32e40x
+compile_flags:
+    +define+ZALRSC
+    +define+PMA_TEST_CFG_X1
+ovpsim: >
+#    --showoverrides
+#    --trace --tracechange --traceshowicount --monitornets
+cflags: >
+    -Wl,--nmagic
+#cv_sw_march: rv32ima_zicsr_zca_zcb_zifencei
+cv_sw_march: rv32ima_zicsr_zca_zcb_zcmp_zifencei #TODO, krdosvik, add zcmp when understanding scrambled gprs
+

--- a/tests/programs/custom/zalrsc/test.yaml
+++ b/tests/programs/custom/zalrsc/test.yaml
@@ -1,0 +1,14 @@
+name: zalrsc
+description: Enables the A extension ZALRSC in the cv32e40x
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+compile_flags:
+    +define+ZALRSC
+    +define+PMA_TEST_CFG_1
+ovpsim: >
+#    --showoverrides
+#    --trace --tracechange --traceshowicount --monitornets
+cflags: >
+    -Wl,--nmagic
+cv_sw_march: rv32ima_zicsr_zca_zcb_zifencei
+#cv_sw_march: rv32ima_zicsr_zca_zcb_zcmp_zifencei #TODO, krdosvik, add when zcmp fail is fixed
+

--- a/tests/programs/custom/zalrsc/zalrsc.c
+++ b/tests/programs/custom/zalrsc/zalrsc.c
@@ -1,0 +1,216 @@
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef enum {
+  MISALIGNED_LRW,
+  MISALIGNED_SCW,
+  UNEXPECTED_IRQ_BEH
+} trap_behavior_t;
+
+// trap handler behavior definitions
+volatile trap_behavior_t trap_handler_beh; //TODO, krdosvik, why volatile?
+volatile uint32_t num_misaligned_LRW_trapped;
+volatile uint32_t num_misaligned_SCW_trapped;
+volatile uint32_t unexpected_irq_beh;
+
+
+int test_LR_SC_sequence_success(void);
+int test_LR_SC_sequence_failure_address_mismatch(void);
+int test_LR_SC_sequence_failure_additional_SC_access(void);
+int test_LRW_misaligned_access(void);
+int test_SCW_misaligned_access(void);
+
+// Checks the mepc for compressed instructions and increments appropriately
+void increment_mepc(void){
+  volatile uint32_t insn, mepc;
+
+  // read the mepc
+  __asm__ volatile("csrrs %0, mepc, x0" : "=r"(mepc));
+
+  // read the contents of the mepc pc.
+  __asm__ volatile("lw %0, (%1)" : "=r"(insn) : "r"(mepc));
+
+  // check for compressed instruction before increment.
+  if ((insn & 0x3) == 0x3) {
+    mepc += 4;
+  } else {
+    mepc += 2;
+  }
+
+  // write to the mepc
+  __asm__ volatile("csrrw x0, mepc, %0" :: "r"(mepc));
+}
+
+// Rewritten interrupt handler
+__attribute__ ((interrupt ("machine")))
+void u_sw_irq_handler(void) {
+
+  switch(trap_handler_beh) {
+
+    case MISALIGNED_LRW :
+      num_misaligned_LRW_trapped += 1;
+      trap_handler_beh = UNEXPECTED_IRQ_BEH;
+      increment_mepc();
+      break;
+
+    case MISALIGNED_SCW :
+      num_misaligned_SCW_trapped += 1;
+      trap_handler_beh = UNEXPECTED_IRQ_BEH;
+      increment_mepc();
+      break;
+
+    default:
+      unexpected_irq_beh += 1;
+      increment_mepc();
+  }
+
+}
+
+//TODO: krdosvik, understand where the flags to the simulator is comming from, and how to use them.
+
+int main(int argc, char *argv[])
+{
+  volatile uint32_t failures=0;
+
+  num_misaligned_LRW_trapped = 0;
+  num_misaligned_SCW_trapped = 0;
+  unexpected_irq_beh = 0;
+  trap_handler_beh = UNEXPECTED_IRQ_BEH;
+
+  failures += test_LR_SC_sequence_success();
+  failures += test_LR_SC_sequence_failure_address_mismatch();
+  failures += test_LR_SC_sequence_failure_additional_SC_access();
+  failures += test_LRW_misaligned_access();
+  failures += test_SCW_misaligned_access();
+  failures += unexpected_irq_beh;
+
+  if(failures == 0){
+    return EXIT_SUCCESS;
+
+  } else if (unexpected_irq_beh) {
+    printf("\n\nTest run fails due to unexpected traps.\n\n");
+    return EXIT_FAILURE;
+
+  } else {
+    return EXIT_FAILURE;
+  }
+}
+
+int test_LR_SC_sequence_success(void)
+{
+  printf("\n\nTest LR.W SC.W sequence constructed to succeed.\n\n");
+
+  volatile uint32_t mem_addr = 0;
+  volatile uint32_t is_failure = 0;
+  volatile uint32_t random = 0;
+
+  mem_addr = (uint32_t)&mem_addr;
+
+  __asm__ volatile("lr.w %0, (%1)"     : "=r" (random)     : "r" (mem_addr));
+  __asm__ volatile("sc.w %0, %1, (%2)" : "=r" (is_failure) : "r" (random), "r" (mem_addr));
+
+  if (is_failure) {
+    printf("Expected sequence to succeed. However, it did not.\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+int test_LR_SC_sequence_failure_address_mismatch(void)
+{
+  printf("\n\nTest LR.W SC.W sequence constructed to fail due to SC.W address mismatch.\n\n");
+
+  volatile uint32_t mem_addr_LRW = 0;
+  volatile uint32_t mem_addr_SCW = 0;
+  volatile uint32_t is_failure = 0;
+  volatile uint32_t random = 0;
+
+  mem_addr_LRW = (uint32_t)&mem_addr_LRW;
+  mem_addr_SCW = (uint32_t)&mem_addr_SCW;
+
+  __asm__ volatile("lr.w %0, (%1)"     : "=r" (random)      : "r" (mem_addr_LRW));
+  __asm__ volatile("sc.w %0, %1, (%2)" : "=r" (is_failure)  : "r" (random), "r" (mem_addr_SCW));
+
+  if (!is_failure) {
+    printf("Expected sequence to fail. However, it did not.\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+int test_LR_SC_sequence_failure_additional_SC_access(void)
+{
+  printf("\n\nTest LR.W SC.W sequence constructed to fail due to additional SC.W access, before SC.W access the address LR.W original reserved.\n\n");
+
+  volatile uint32_t mem_addr;
+  volatile uint32_t mem_addr_additional_SCW;
+  volatile uint32_t is_failure_additional_SCW;
+  volatile uint32_t is_failure;
+  volatile uint32_t random;
+
+  mem_addr                = (uint32_t)&mem_addr;
+  mem_addr_additional_SCW = (uint32_t)&mem_addr_additional_SCW;
+
+  __asm__ volatile("lr.w %0, (%1)"     : "=r" (random)                    : "r" (mem_addr));
+  __asm__ volatile("sc.w %0, %1, (%2)" : "=r" (is_failure_additional_SCW) : "r" (random), "r" (mem_addr_additional_SCW)); //TODO: krdosvik, not 100% sure if this should fail?
+  __asm__ volatile("sc.w %0, %1, (%2)" : "=r" (is_failure)                : "r" (random), "r" (mem_addr));
+
+  if (!is_failure_additional_SCW) {
+    printf("Expected SCW instruction to fail. However, it did not.\n");
+    return 1;
+  } else if (!is_failure) {
+    printf("Expected sequence to fail. However, it did not.\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+int test_LRW_misaligned_access(void)
+{
+  printf("\n\nTest that a misaligned LR.W instruction fails.\n\n");
+
+  volatile uint32_t mem_addr_misaligned;
+  volatile uint32_t random;
+
+  mem_addr_misaligned = ((uint32_t)&mem_addr_misaligned) +1;
+  trap_handler_beh = MISALIGNED_LRW;
+
+  __asm__ volatile("lr.w %[random], (%[mem_addr_misaligned])" : [random]"=r" (random) : [mem_addr_misaligned]"r" (mem_addr_misaligned));
+
+  //(Execute exception handler)
+
+  if (num_misaligned_LRW_trapped != 1) {
+    printf("Expected LRW to trap due to misaligned address. However, it did not.\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+int test_SCW_misaligned_access(void)
+{
+  printf("\n\nTest that a misaligned SC.W instruction fails.\n\n");
+
+  volatile uint32_t mem_addr_misaligned;
+  volatile uint32_t is_failure;
+  volatile uint32_t random;
+
+  mem_addr_misaligned = ((uint32_t)&mem_addr_misaligned) +1;
+  trap_handler_beh = MISALIGNED_SCW;
+
+  __asm__ volatile("sc.w %[is_failure], %[random], (%[mem_addr_misaligned])" : [is_failure]"=r" (is_failure) : [random]"r" (random), [mem_addr_misaligned]"r" (mem_addr_misaligned));
+
+  //(Execute exception handler)
+
+  if (num_misaligned_SCW_trapped != 1) {
+    printf("Expected SCW to trap due to misaligned address. However, it did not.\n");
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
1) Add zalrsc sanity checking 
2) Enable a extention in ISACOV
3) Include zalrsc without ISS in full regression

formal: compiles
ci_check: passes except pma_2

Connected to PR  https://github.com/openhwgroup/core-v-verif/pull/2252