### PR TITLE
Add atomic assertions verifying PMA, add coverage points

### DIFF
--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -713,7 +713,9 @@ module uvmt_cv32e40x_tb;
     //Atomic assert
     bind  dut_wrap.cv32e40x_wrapper_i
     uvmt_cv32e40x_atomic_assert #(
-      .A_EXT (A_EXT)
+      .A_EXT (A_EXT),
+      .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
+      .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG)
     ) atomic_assert_i (
       .clknrst_if              (dut_wrap.clknrst_if),
       .rvfi_if                 (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),
@@ -923,6 +925,7 @@ module uvmt_cv32e40x_tb;
         .pma_status_rvfidata_word0lowbyte_i  (uvmt_cv32e40x_tb.pma_status_rvfidata_word0lowbyte),
         .pma_status_rvfidata_word0highbyte_i (uvmt_cv32e40x_tb.pma_status_rvfidata_word0highbyte),
         .rvfi_if                             (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),
+        .support_if                          (support_logic_module_o_if.slave_mp),
         .*
       );
 
@@ -937,6 +940,7 @@ module uvmt_cv32e40x_tb;
         .pma_status_rvfidata_word0lowbyte_i  (uvmt_cv32e40x_tb.pma_status_rvfidata_word0lowbyte),
         .pma_status_rvfidata_word0highbyte_i (uvmt_cv32e40x_tb.pma_status_rvfidata_word0highbyte),
         .rvfi_if                             (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),
+        .support_if                          (support_logic_module_o_if.slave_mp),
         .*
       );
 


### PR DESCRIPTION
Add atomic assertions verifying PMA,
Add coverage points

ci check passes (except a timeout of the corev_rand_interrupt test).
Formal compiles.
Added assertions and coverpoints passes.

PMA vplan is updated here: https://github.com/openhwgroup/core-v-verif/pull/2284

Drafth: Did some mistakes when checking firstfail cp, so the change might not be needed, test is running)