### PR TITLE
support RV32E in atomic asserts, add atomic to regression list

### DIFF
--- a/regress/cv32e40x_full.yaml
+++ b/regress/cv32e40x_full.yaml
@@ -104,6 +104,10 @@ builds:
     cfg: debug_trigger_cfg4
     dir: cv32e40x/sim/uvmt
 
+  uvmt_cv32e40x_TEMPORARY_zalrsc:
+    cmd: make comp_corev-dv comp
+    cfg: TEMPORARY_zalrsc
+    dir: cv32e40x/sim/uvmt
 
 # List of tests
 tests:
@@ -522,8 +526,8 @@ tests:
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=wfe_test
 
-  #zalrsc: #TODO, krdosvik, add test when no problem running zalrsc test with ISS
-  #  description: Sanity test of ZALRSC extention
-  #  builds: [ uvmt_cv32e40x_clic ]
-  #  dir: cv32e40x/sim/uvmt
-  #  cmd: make test TEST=zalrsc
+  zalrsc:
+    description: Sanity test of ZALRSC extention
+    builds: [ uvmt_cv32e40x_TEMPORARY_zalrsc ]
+    dir: cv32e40x/sim/uvmt
+    cmd: make test TEST=zalrsc

--- a/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -150,7 +150,6 @@ module uvmt_cv32e40x_dut_wrap
 
          .irq_i                  ( interrupt_if.irq               ),
          .wu_wfe_i               ( wfe_wu_if.wfe_wu               ),
-         .wu_wrs_i               (1'b0                            ),
          .clic_irq_i             ( clic_if.clic_irq               ),
          .clic_irq_id_i          ( clic_if.clic_irq_id            ),
          .clic_irq_level_i       ( clic_if.clic_irq_level         ),

--- a/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -150,6 +150,7 @@ module uvmt_cv32e40x_dut_wrap
 
          .irq_i                  ( interrupt_if.irq               ),
          .wu_wfe_i               ( wfe_wu_if.wfe_wu               ),
+         .wu_wrs_i               (1'b0                            ),
          .clic_irq_i             ( clic_if.clic_irq               ),
          .clic_irq_id_i          ( clic_if.clic_irq_id            ),
          .clic_irq_level_i       ( clic_if.clic_irq_level         ),

--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -735,7 +735,7 @@ module uvmt_cv32e40x_tb;
       .A_EXT           (A_EXT),
       .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
       .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG),
-      .RV32            (cv32e40x_pkg::RV32E)
+      .RV32            (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_RV32)
     ) atomic_assert_i (
       .clknrst_if              (dut_wrap.clknrst_if),
       .rvfi_if                 (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),

--- a/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -732,9 +732,10 @@ module uvmt_cv32e40x_tb;
     //Atomic assert
     bind  dut_wrap.cv32e40x_wrapper_i
     uvmt_cv32e40x_atomic_assert #(
-      .A_EXT (A_EXT),
+      .A_EXT           (A_EXT),
       .PMA_NUM_REGIONS (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-      .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG)
+      .PMA_CFG         (uvmt_cv32e40x_base_test_pkg::CORE_PARAM_PMA_CFG),
+      .RV32            (cv32e40x_pkg::RV32E)
     ) atomic_assert_i (
       .clknrst_if              (dut_wrap.clknrst_if),
       .rvfi_if                 (dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if),

--- a/tests/cfg/TEMPORARY_zalrsc.yaml
+++ b/tests/cfg/TEMPORARY_zalrsc.yaml
@@ -1,10 +1,11 @@
 name: TEMPORARY_zalrsc
 description: Enables the ZALRSC extension, and disables the zcmp extentnion. TODO, krdosvik, remove this configuration when no problem running zalrsc test with ISS=1, so until then run with ISS=0.
 compile_flags:
-    +define+ZALRSC
+    +define+A
+    #+define+ZALRSC TODO: use zalrsc when ISS is up to date.
 ovpsim: >
-    --showoverrides
-    --trace --tracechange --traceshowicount --monitornets
+    #--showoverrides
+    #--trace --tracechange --traceshowicount --monitornets
 cflags: >
     -Wl,--nmagic
 cv_sw_march: rv32ima_zicsr_zca_zcb_zcmp_zifencei


### PR DESCRIPTION
Make sure atomic assert support RV32E configuration.
Add atomic test to regression list. 
Assertions passes in formal.
ci check passes.